### PR TITLE
Add size attribute that affects internal core-icon

### DIFF
--- a/core-icon-button.css
+++ b/core-icon-button.css
@@ -11,8 +11,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   display: inline-block;
   box-sizing: border-box;
   -moz-box-sizing: border-box;
-  width: 38px;
-  height: 38px;
+  width: auto;
+  height: auto;
   background-image: none;
   border-radius: 2px;
   padding: 7px;

--- a/core-icon-button.html
+++ b/core-icon-button.html
@@ -28,13 +28,13 @@ how to use a custom icon set.
 <link rel="import" href="../core-icon/core-icon.html">
 <link rel="import" href="../core-icons/core-icons.html">
 
-<polymer-element name="core-icon-button" attributes="src icon active">
+<polymer-element name="core-icon-button" attributes="src icon active size">
 
   <template>
 
     <link rel="stylesheet" href="core-icon-button.css">
 
-    <core-icon src="{{src}}" icon="{{icon}}"><content></content></core-icon>
+    <core-icon src="{{src}}" icon="{{icon}}" size="{{size}}"><content></content></core-icon>
 
   </template>
 
@@ -72,6 +72,15 @@ how to use a custom icon set.
        * @default ''
        */
       icon: '',
+
+      /**
+       * Specifies the size of the icon in pixel units.
+       *
+       * @attribute size
+       * @type string
+       * @default 24
+       */
+      size: 24,
 
       activeChanged: function() {
         this.classList.toggle('selected', this.active);


### PR DESCRIPTION
Referencing https://github.com/Polymer/core-icon-button/issues/3

This is an easy, clean way to expose the size attribute of the internal `core-icon` element. The demo page did not change appearance at all for me with these changes.
