### PR TITLE
Remove explicit width and height

### DIFF
--- a/core-icon-button.css
+++ b/core-icon-button.css
@@ -11,8 +11,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   display: inline-block;
   box-sizing: border-box;
   -moz-box-sizing: border-box;
-  width: 38px;
-  height: 38px;
   background-image: none;
   border-radius: 2px;
   padding: 7px;


### PR DESCRIPTION
Fixes #3

The `core-icon` already has a default width/height of 24px so we don't need one here. Removing it allows the `core-icon-button` to automatically scale up when the `core-icon`'s width and height change.
