### PR TITLE
Fixing link to `core-iconset`

### DIFF
--- a/core-icon-button.html
+++ b/core-icon-button.html
@@ -17,7 +17,7 @@ which icon from the icon set to use.
 
     <core-icon-button icon="menu"></core-icon-button>
 
-See [`core-iconset`](#core-iconset) for more information about 
+See [`core-iconset`](core-iconset.html) for more information about 
 how to use a custom icon set.
 
 @group Polymer Core Elements


### PR DESCRIPTION
"See `core-iconset` for more information about..." wrongly linked to `#core-iconset`. Changed to `core-iconset.html`